### PR TITLE
支持等待 .detach() 创建的协程

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,7 @@
 set_target_properties(ucoro_tests PROPERTIES FOLDER "ucoro_tests")
 
 add_subdirectory(test1)
+add_subdirectory(test2)
 
 find_package(Boost 1.60 COMPONENTS thread system atomic)
 if(Boost_FOUND)

--- a/tests/test2/CMakeLists.txt
+++ b/tests/test2/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+add_executable(test2 test2.cpp)
+target_link_libraries(test2 ucoro)
+
+add_test(NAME test2 COMMAND test2)
+set_target_properties(test2 PROPERTIES FOLDER "ucoro_tests")

--- a/tests/test2/test2.cpp
+++ b/tests/test2/test2.cpp
@@ -1,0 +1,47 @@
+#include <iostream>
+#include "ucoro/awaitable.hpp"
+
+
+ucoro::awaitable<int> coro_compute_int(int value)
+{
+	co_return (value * 100);
+}
+
+ucoro::awaitable<void> coro_compute_exec(int value)
+{
+	auto x = co_await ucoro::local_storage;
+	std::cout << "local storage: " << std::any_cast<std::string>(x) << std::endl;
+
+	try
+	{
+		auto y = co_await ucoro::local_storage_t<std::string>();
+		std::cout << "local storage: " << y << std::endl;
+	}
+	catch (const std::exception& e)
+	{
+		std::cout << e.what();
+	}
+
+	auto comput_promise = coro_compute_int(value);
+
+	auto ret = co_await std::move(comput_promise);
+	std::cout << "return: " << ret << std::endl;
+}
+
+ucoro::awaitable<void> coro_compute()
+{
+	for (auto i = 0; i < 100; i+=2)
+	{
+		co_await coro_compute_exec(i);
+		co_await coro_compute_exec(i+1).detach(std::string{"hello from detached coro"});
+	}
+}
+
+int main(int argc, char **argv)
+{
+	std::string str = "hello from main coro";
+
+	coro_start(coro_compute(), str);
+
+	return 0;
+}


### PR DESCRIPTION
当调用 .detach(), 然后不等待它，那么这个 detch 的协程就直接后台跑了。就好像 create_thread
创建了个新线程一样。

当调用 .detach(), 然后使用 co_await 等待它，那么当前协程就等待这个 detach 的协程完成。
就好像调用 std.thread.join() 那样。