### PR TITLE
不需要为 qt 特意使用 Debug 版本 静态库

### DIFF
--- a/tests/testqt/CMakeLists.txt
+++ b/tests/testqt/CMakeLists.txt
@@ -3,7 +3,7 @@ qt_standard_project_setup()
 
 qt_add_executable(testqt testqt.cpp)
 
-set_property(TARGET testqt PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+set_property(TARGET testqt PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded")
 set_target_properties(testqt PROPERTIES FOLDER "ucoro_tests")
 target_link_libraries(testqt PRIVATE ucoro Qt6::Core)
 


### PR DESCRIPTION
反而会遇到

[build] Qt6Core.lib(qcoreevent.cpp.obj) : error LNK2038: 检测到“_ITERATOR_DEBUG_LEVEL”的不匹配项: 值“0”不匹配值“2”(testqt.cpp.obj 中)
[build] Qt6Core.lib(qcoreevent.cpp.obj) : error LNK2038: 检测到“RuntimeLibrary”的不匹配项: 值“MT_StaticRelease”不匹配值“MTd_StaticDebug”(testqt.cpp.obj 中)
[build] Qt6Core.lib(qdatastream.cpp.obj) : error LNK2038: 检测到“_ITERATOR_DEBUG_LEVEL”的不匹配项: 值“0”不匹配值“2”(testqt.cpp.obj 中)
[build] Qt6Core.lib(qdatastream.cpp.obj) : error LNK2038: 检测到“RuntimeLibrary”的不匹配项: 值“MT_StaticRelease”不匹配值“MTd_StaticDebug”(testqt.cpp.obj 中)
[build] Qt6Core.lib(qdeadlinetimer.cpp.obj) : error LNK2038: 检测到“_ITERATOR_DEBUG_LEVEL”的不匹配项: 值“0”不匹配值“2”(testqt.cpp.obj 中)
[build] Qt6Core.lib(qdeadlinetimer.cpp.obj) : error LNK2038: 检测到“RuntimeLibrary”的不匹配项: 值“MT_StaticRelease”不匹配值“MTd_StaticDebug”(testqt.cpp.obj 中)
[build] Qt6Core.lib(qstringlist.cpp.obj) : error LNK2038: 检测到“_ITERATOR_DEBUG_LEVEL”的不匹配项: 值“0”不匹配值“2”(testqt.cpp.obj 中)
[build] Qt6Core.lib(qstringlist.cpp.obj) : error LNK2038: 检测到“RuntimeLibrary”的不匹配项: 值“MT_StaticRelease”不匹配值“MTd_StaticDebug”(testqt.cpp.obj 中)
[build] Qt6Core.lib(qeventloop.cpp.obj) : error LNK2038: 检测到“_ITERATOR_DEBUG_LEVEL”的不匹配项: 值“0”不匹配值“2”(testqt.cpp.obj 中)
[build] Qt6Core.lib(qeventloop.cpp.obj) : error LNK2038: 检测到“RuntimeLibrary”的不匹配项: 值“MT_StaticRelease”不匹配值“MTd_StaticDebug”

修正后，不管 Debug 还是 Release 都能正常编译通过。