### PR TITLE
删除 awaitable_detached<> 类。减少代码重复

### DIFF
--- a/tests/test3/test.cpp
+++ b/tests/test3/test.cpp
@@ -7,6 +7,8 @@ int main(int argc, char **argv)
 	using CallbackAwaiterType0 = ucoro::CallbackAwaiter<void, decltype([](auto h) {}) >;
 	using CallbackAwaiterType1 = ucoro::CallbackAwaiter<int, decltype([](auto h) {}) > ;
 
+	static_assert(ucoro::detail::is_instance_of_v<ucoro::local_storage_t<void>, ucoro::local_storage_t>, "not a local_storage_t");
+
 	static_assert(ucoro::detail::is_awaiter_v < CallbackAwaiterType0 >, "not a coroutine");
 	static_assert(ucoro::detail::is_awaiter_v < CallbackAwaiterType1 >, "not a coroutine");
 


### PR DESCRIPTION
awaitable_detached 自从支持自身被 co_await 后，代码变得越来越像 awaitable<T>
相似度极高。

既然如此，不如合并代码。 detach 的时候，创建一个新的 awaitable<>。

有没有 detach 其实根本原因在于有没有被 co_await.

因此，在 析构函数里，判断是不是 done() 即可知道有没有被 co_await 过了。
如果没有被 co_await 过，则是 detach 模式。在析构里把协程给 resume 起来。

由于析构的时候没有进行 destroy 操作，因此需要在 final_awaiter 里进行清理。
现在 final_awaiter<T> 的部分清理逻辑本身就是从
awaitable_detached::promise_type::final_awaiter 里合并进来的。

同时detach 模式使用 awaitable<T> 后，也修正了 detach 模式下吞异常的问题。