### PR TITLE
删除 ExecutorAwaiter 的前置声明

### DIFF
--- a/include/ucoro/awaitable.hpp
+++ b/include/ucoro/awaitable.hpp
@@ -62,9 +62,6 @@ namespace ucoro
 	struct awaitable_promise;
 
 	template<typename T, typename CallbackFunction>
-	struct ExecutorAwaiter;
-
-	template<typename T, typename CallbackFunction>
 	struct CallbackAwaiter;
 
 	template<typename T>


### PR DESCRIPTION
删除 executor_awaitable 的时候，漏删了这个前置声明

删之