### PR TITLE
类型萃取的代码添加更多的注释。这部分东西永远是 c++ 里最晦涩难懂的

### DIFF
--- a/tests/test3/test.cpp
+++ b/tests/test3/test.cpp
@@ -7,15 +7,19 @@ int main(int argc, char **argv)
 	using CallbackAwaiterType0 = ucoro::CallbackAwaiter<void, decltype([](auto h) {}) >;
 	using CallbackAwaiterType1 = ucoro::CallbackAwaiter<int, decltype([](auto h) {}) > ;
 
-	static_assert(ucoro::detail::is_instance_of_v<ucoro::local_storage_t<void>, ucoro::local_storage_t>, "not a local_storage_t");
+	static_assert(ucoro::concepts::local_storage_type<ucoro::local_storage_t<void>>, "not a local_storage_t");
 
-	static_assert(ucoro::detail::is_awaiter_v < CallbackAwaiterType0 >, "not a coroutine");
-	static_assert(ucoro::detail::is_awaiter_v < CallbackAwaiterType1 >, "not a coroutine");
+	using local_storage_template_parameter = ucoro::traits::template_parameter_of<decltype(ucoro::local_storage), ucoro::local_storage_t>;
 
-	static_assert(ucoro::detail::is_awaiter_v < ucoro::awaitable<void> >, "not a coroutine");
-	static_assert(ucoro::detail::is_awaiter_v < ucoro::awaitable<int> >, "not a coroutine");
+	static_assert(std::is_void_v<local_storage_template_parameter>, "local_storage is not local_storage_t<void>");
 
-	static_assert(!ucoro::detail::is_awaiter_v < int >, "not a coroutine");
+	static_assert(ucoro::concepts::is_awaiter_v<CallbackAwaiterType0>, "not a coroutine");
+	static_assert(ucoro::concepts::is_awaiter_v<CallbackAwaiterType1>, "not a coroutine");
+
+	static_assert(ucoro::concepts::is_awaiter_v<ucoro::awaitable<void>>, "not a coroutine");
+	static_assert(ucoro::concepts::is_awaiter_v<ucoro::awaitable<int>>, "not a coroutine");
+
+	static_assert(!ucoro::concepts::is_awaiter_v<int>, "not a coroutine");
 
 	return 0;
 }


### PR DESCRIPTION
为没有可读性的代码添加注释

这也是 c++ 需要改进的地方。类型萃取不应该靠不直观的偏特化实现